### PR TITLE
Fix existing behaviours in order to adapt to latest Depot version

### DIFF
--- a/lib/depot_s3.ex
+++ b/lib/depot_s3.ex
@@ -115,7 +115,7 @@ defmodule DepotS3 do
   end
 
   @impl Depot.Adapter
-  def write(%Config{} = config, path, contents) do
+  def write(%Config{} = config, path, contents, _opts \\ []) do
     path = Depot.RelativePath.join_prefix(config.prefix, path)
 
     operation = ExAws.S3.put_object(config.bucket, path, contents)
@@ -194,14 +194,14 @@ defmodule DepotS3 do
   end
 
   @impl Depot.Adapter
-  def move(%Config{} = config, source, destination) do
+  def move(%Config{} = config, source, destination, _opts \\ []) do
     with :ok <- copy(config, source, destination) do
       delete(config, source)
     end
   end
 
   @impl Depot.Adapter
-  def copy(%Config{} = config, source, destination) do
+  def copy(%Config{} = config, source, destination, _opts \\ []) do
     source = Depot.RelativePath.join_prefix(config.prefix, source)
     destination = Depot.RelativePath.join_prefix(config.prefix, destination)
     do_copy(config.config, {config.bucket, source}, {config.bucket, destination})
@@ -219,7 +219,7 @@ defmodule DepotS3 do
   end
 
   @impl Depot.Adapter
-  def copy(%Config{} = source_config, source, %Config{} = destination_config, destination) do
+  def copy(%Config{} = source_config, source, %Config{} = destination_config, destination, _opts \\ []) do
     case {source_config.config, destination_config.config} do
       # Cross bucket copy
       {config, config} ->
@@ -294,7 +294,7 @@ defmodule DepotS3 do
   end
 
   @impl Depot.Adapter
-  def create_directory(config, path) do
+  def create_directory(config, path, _opts \\ []) do
     write(config, path, "")
   end
 


### PR DESCRIPTION
Since Depot 0.5.2 it has been introduced visibility handling, which breaks compatibility on write interfaces of the adapter behaviour.

This PR fixes the issue by inserting an unused, defaulted keyword, in order to ensure compatibility for usage with both pre-0.5.2 and post-0.5.2 releases

Same fixes should be applied to other official depot adapters (Google Cloud Storage), even if it would be better to preserve compatibility with original interface on Depot library