### PR TITLE
Compatibility and fix for `list_contents` when working when subfolders

### DIFF
--- a/lib/depot_s3.ex
+++ b/lib/depot_s3.ex
@@ -275,9 +275,6 @@ defmodule DepotS3 do
         [] -> {nil, filename}
       end
 
-      IO.inspect("DEBUG\nFILE: #{__ENV__.file}\nLINE: #{__ENV__.line}")
-      IO.inspect({path, files, folder, filename_isolated})
-
       case {folder, filename_isolated} do
         {nil, _} -> acc
 

--- a/lib/depot_s3.ex
+++ b/lib/depot_s3.ex
@@ -115,7 +115,7 @@ defmodule DepotS3 do
   end
 
   @impl Depot.Adapter
-  def write(%Config{} = config, path, contents) do
+  def write(%Config{} = config, path, contents, _opts) do
     path = Depot.RelativePath.join_prefix(config.prefix, path)
 
     operation = ExAws.S3.put_object(config.bucket, path, contents)
@@ -194,14 +194,14 @@ defmodule DepotS3 do
   end
 
   @impl Depot.Adapter
-  def move(%Config{} = config, source, destination) do
-    with :ok <- copy(config, source, destination) do
+  def move(%Config{} = config, source, destination, opts) do
+    with :ok <- copy(config, source, destination, opts) do
       delete(config, source)
     end
   end
 
   @impl Depot.Adapter
-  def copy(%Config{} = config, source, destination) do
+  def copy(%Config{} = config, source, destination, _opts) do
     source = Depot.RelativePath.join_prefix(config.prefix, source)
     destination = Depot.RelativePath.join_prefix(config.prefix, destination)
     do_copy(config.config, {config.bucket, source}, {config.bucket, destination})
@@ -219,7 +219,7 @@ defmodule DepotS3 do
   end
 
   @impl Depot.Adapter
-  def copy(%Config{} = source_config, source, %Config{} = destination_config, destination) do
+  def copy(%Config{} = source_config, source, %Config{} = destination_config, destination, _opts) do
     case {source_config.config, destination_config.config} do
       # Cross bucket copy
       {config, config} ->
@@ -294,8 +294,8 @@ defmodule DepotS3 do
   end
 
   @impl Depot.Adapter
-  def create_directory(config, path) do
-    write(config, path, "")
+  def create_directory(config, path, opts) do
+    write(config, path, "", opts)
   end
 
   @impl Depot.Adapter
@@ -337,5 +337,15 @@ defmodule DepotS3 do
   @impl Depot.Adapter
   def clear(config) do
     delete_directory(config, "/", recursive: true)
+  end
+
+  @impl Depot.Adapter
+  def set_visibility(_config, _path, _visibility) do
+    {:error, :unsupported}
+  end
+
+  @impl Depot.Adapter
+  def visibility(config, path) do
+    {:error, :unsupported}
   end
 end

--- a/test/depot_s3_test.exs
+++ b/test/depot_s3_test.exs
@@ -46,5 +46,16 @@ defmodule DepotS3Test do
 
       assert {:ok, "Hello World"} = Depot.read(filesystem_b, "other.txt")
     end
+
+    test "file listing", %{config_a: config_a} do
+      filesystem = DepotS3.configure(config: config_a, bucket: "default")
+
+      :ok = Depot.write(filesystem, "testone.txt", "Hello World")
+      :ok = Depot.write(filesystem, "folder/testtwo.txt", "Hello World")
+      :ok = Depot.write(filesystem, "folder/subfolder/testthree.txt", "Hello World")
+      :ok = Depot.write(filesystem, "folder/subfolder/testfour.txt", "Hello World")
+
+      assert {:ok, [%Depot.Stat.Dir{name: "subfolder", size: 22}, %Depot.Stat.File{name: "testtwo.txt"}]} = Depot.list_contents(filesystem, "folder")
+    end
   end
 end


### PR DESCRIPTION
This will establish compatibility with changes introduced in d48e7c6 and fix the directory listing `list_contents/2` when listing files in sub-directories.

Given the following setup:
```
.
└── A
    ├── B
    │   ├── one.txt
    │   ├── two.txt
    │   └── X
    │       ├── three.txt
    │       └── four.txt
    └── C
        ├── five.txt
        └── six.txt
```

In earlier versions `MyFilesystem.list_contents(".")` would correctly yield `A` with a summed up size.
However calling `MyFilesystem.list_contents("A")` would **still** only yield `A` while I'd except to see `B` and `C`. Calling `MyFilesystem.list_contents("A/B")` respectively would again only yield `A` rather than the files `one.txt` and `two.txt` as well as the folder `X` (with its file sizes summed up).
